### PR TITLE
Support for x-enum-fallback-value field in enums.

### DIFF
--- a/datamodel_code_generator/model/enum.py
+++ b/datamodel_code_generator/model/enum.py
@@ -46,6 +46,7 @@ class Enum(DataModel):
         description: Optional[str] = None,
         type_: Optional[Types] = None,
         default: Any = UNDEFINED,
+        fallback: Any = UNDEFINED,
     ):
 
         super().__init__(
@@ -69,6 +70,9 @@ class Enum(DataModel):
                     BaseClassDataType(type=base_class),
                     *self.base_classes,
                 ]
+
+        if fallback != UNDEFINED:
+            self.extra_template_data.update({"fallback": fallback})
 
     @classmethod
     def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:

--- a/datamodel_code_generator/model/template/Enum.jinja2
+++ b/datamodel_code_generator/model/template/Enum.jinja2
@@ -15,3 +15,8 @@ class {{ class_name }}({{ base_class }}):
     """
     {%- endif %}
 {%- endfor -%}
+{%- if fallback %}
+    @classmethod
+    def _missing_(cls, value):
+      return {{ class_name }}.{{ fallback }}
+{%- endif %}

--- a/tests/data/expected/parser/openapi/openapi_parser_x_enum_fallback_value/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_x_enum_fallback_value/output.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class EnumTypeWithFallback(Enum):
+    a = 'a'
+    b = 'b'
+    unknown = 'unknown'
+
+    @classmethod
+    def _missing_(cls, value):
+        return EnumTypeWithFallback.unknown
+
+
+class EnumTypeWithFallbackExistingField(Enum):
+    a = 'a'
+    b = 'b'
+    unknown = 'unknown'
+
+    @classmethod
+    def _missing_(cls, value):
+        return EnumTypeWithFallbackExistingField.unknown
+
+
+class EnumTypeWithFallbackAndDifferentDefault(Enum):
+    a = 'a'
+    b = 'b'
+    unknown = 'unknown'
+
+    @classmethod
+    def _missing_(cls, value):
+        return EnumTypeWithFallbackAndDifferentDefault.unknown
+
+
+class EnumTypeWithFallbackAndSameDefault(Enum):
+    a = 'a'
+    b = 'b'
+    unknown = 'unknown'
+
+    @classmethod
+    def _missing_(cls, value):
+        return EnumTypeWithFallbackAndSameDefault.unknown
+
+
+class TopLevelModel(BaseModel):
+    enum_field: EnumTypeWithFallback
+    enum_field_with_default: Optional[EnumTypeWithFallbackAndDifferentDefault] = 'a'
+    enum_field_with_default_fallback: Optional[
+        EnumTypeWithFallbackAndSameDefault
+    ] = 'unknown'

--- a/tests/data/openapi/x_enum_fallback_value.yaml
+++ b/tests/data/openapi/x_enum_fallback_value.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0
+components:
+  schemas:
+    enum_type_with_fallback:
+      type: string
+      description: Enum field with fallback value 'unknown'.
+      enum:
+        - 'a'
+        - 'b'
+      x-enum-fallback-value: 'unknown'
+
+    enum_type_with_fallback_existing_field:
+      type: string
+      description: Enum field with fallback value 'unknown'.
+      enum:
+        - 'a'
+        - 'b'
+        - 'unknown'
+      x-enum-fallback-value: 'unknown'
+
+    enum_type_with_fallback_and_different_default:
+      type: string
+      description: Enum field with default value 'a' and fallback value 'unknown'.
+      enum:
+        - 'a'
+        - 'b'
+        - 'unknown'
+      default: 'a'
+      x-enum-fallback-value: 'unknown'
+
+    enum_type_with_fallback_and_same_default:
+      type: string
+      description: Enum field with default value and fallback value 'unknown'.
+      enum:
+        - 'a'
+        - 'b'
+        - 'unknown'
+      default: 'unknown'
+      x-enum-fallback-value: 'unknown'
+
+    TopLevelModel:
+      required:
+        - enum_field
+      properties:
+        enum_field:
+          $ref: "#/components/schemas/enum_type_with_fallback"
+        enum_field_with_default:
+          $ref: "#/components/schemas/enum_type_with_fallback_and_different_default"
+        enum_field_with_default_fallback:
+          $ref: "#/components/schemas/enum_type_with_fallback_and_same_default"

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -379,6 +379,14 @@ class UnknownTypeNumber(Enum):
     )
 
 
+def test_openapi_parser_parse_x_enum_fallback_value():
+    parser = OpenAPIParser(
+        Path(DATA_PATH / 'x_enum_fallback_value.yaml'),
+    )
+    expected_dir = EXPECTED_OPEN_API_PATH / 'openapi_parser_x_enum_fallback_value'
+    assert parser.parse() == (expected_dir / 'output.py').read_text()
+
+
 @pytest.mark.skipif(
     pydantic.VERSION < '1.9.0', reason='Require Pydantic version 1.9.0 or later '
 )


### PR DESCRIPTION
If specified, enum will fall back to this value if input value is not part of enum list.

Spec file:
```yaml
openapi: 3.0
components:
  schemas:
    enum_type_with_fallback:
      type: string
      description: Enum field with fallback value 'unknown'.
      enum:
        - 'a'
        - 'b'
      x-enum-fallback-value: 'unknown'
```

Generated code:
```python
class EnumTypeWithFallback(Enum):
    a = 'a'
    b = 'b'
    unknown = 'unknown'

    @classmethod
    def _missing_(cls, value):
        return EnumTypeWithFallback.unknown
```

Usage:
```python
>>> EnumFieldWithFallback("a")
<EnumFieldWithFallback.a: 'a'>

>>> EnumFieldWithFallback("c")
<EnumFieldWithFallback.unknown: 'unknown'>
```
